### PR TITLE
add namespace to install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/README.md TYPE DOC)
 
 # Install the export
 install(EXPORT ${TARGET}Targets
+        NAMESPACE erkir::
         FILE ${TARGET}Targets.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET}
 )


### PR DESCRIPTION
Hi, I needed to add namespace for vcpkg installs to work.  Also here is the portfile I used.  If there is some way to make this obvious it might make it easier for others to rope in via vcpkg, if they are using that for dep management!

`
vcpkg_from_github(
    OUT_SOURCE_PATH SOURCE_PATH
    REPO erandtke/erkir
    REF 0b8576235fc0e52769dde134d0f5258529c3596d
    SHA512 7539a7324d2fed5e9a520823b7f0e089a864c2c8235b025315da2390d3319c201ffed8c3ce8cc2a8b4e4cefabe9f257640fc90cc4c41c33b8732924e386dce50
)
vcpkg_cmake_configure(
    SOURCE_PATH "${SOURCE_PATH}"
)
vcpkg_cmake_install()
vcpkg_cmake_config_fixup(PACKAGE_NAME erkir CONFIG_PATH lib/cmake/erkir)
`